### PR TITLE
Fixed errors during rollup not rejecting the promise.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -41,7 +41,7 @@ function createPreprocessor (args, config, logger, helper)
                 })
                 .catch(function (error)
                 {
-                    log.error('%s\n  at %s:%d', e.message, file.originalPath, e.location.first_line)
+                    log.error('Failed to process "%s".\n  %s', file.originalPath, error.message);
                     done(error, null)
                 });
 


### PR DESCRIPTION
The logging was reading from `e` instead of `error`, causing an exception to be thrown. This meant the `done()` function did not get called in case of build failure, and the tests would freeze up.

Also updated the error message to reflect that it was the rollup of the `originalPath` that failed - the `location` from the error had nothing to do with it - in fact it is under `error.loc.line` if you need it. But it looks like the message contains the location info anyway.

**Output from a syntax error:**
```
21 02 2016 18:09:06.932:ERROR [preprocessor.rollup]: Failed to process "/Users/Mats/Documents/Code/redux-preact-test/test/test-reducers.js".
  /Users/Mats/Documents/Code/redux-preact-test/src/actions.js: Unexpected token (3:7)
```
**Output from other kinds of error:**
```
21 02 2016 18:18:58.552:ERROR [preprocessor.rollup]: Failed to process "/Users/Mats/Documents/Code/redux-preact-test/test/test-actions.js".
  Module /Users/Mats/Documents/Code/redux-preact-test/src/validation.js does not export isArrayOf (imported by /Users/Mats/Documents/Code/redux-preact-test/src/actions.js)
```